### PR TITLE
adding widget to interact with valOpts (headerLevelStart) as numbers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -89,6 +89,10 @@ h3 {
     font-family: 'Open Sans', 'Myriad Pro', 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', Geneva, Verdana, sans-serif;
 }
 
+.lateral-menu label {
+    color: rgb(144, 144, 144);
+}
+
 .lateral-menu-content {
     padding-left: 10px;
     height: 100%;

--- a/index.html
+++ b/index.html
@@ -44,6 +44,16 @@
         <div ng-repeat="opt in checkOpts">
           <input ng-click="updateOptions()" type="checkbox" ng-model="opt.value" />&nbsp;&nbsp;{{opt.name}}<br />
         </div>
+        <div ng-repeat="opt in valOpts">
+          <div class="row collapse prefix-radius">
+            <div class="small-8 columns inline">
+              <label for="option-{opt.name}" class="right inline">{{opt.name}}&nbsp;&nbsp;</label>
+            </div>
+            <div class="small-4 columns">
+              <input id="option-{opt.name}" ng-change="updateOptions()" type="number" ng-model="opt.value"/>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This is a quick patch for https://github.com/showdownjs/demo/issues/1
It also needs to change the label color (too dark by default).

Given that there is only headerLevelStart for now, I considered the options as being numbers (a "type" could be added to the option later if really needed).
